### PR TITLE
Support spaces in Linux executable name

### DIFF
--- a/Deploy/metafilemanager.cpp
+++ b/Deploy/metafilemanager.cpp
@@ -84,7 +84,7 @@ bool MetaFileManager::createRunScriptLinux(const QString &target) {
             "platforms:$QT_QPA_PLATFORM_PLUGIN_PATH\n"
             "%2"
             "%3\n"
-            "\"$BASE_DIR\"" + distro.getBinOutDir() + "%1 \"$@\"";
+            "\"$BASE_DIR" + distro.getBinOutDir() + "%1\" \"$@\"";
 
     content = content.arg(QFileInfo(target).fileName());
     int ld_index = DeployCore::find("ld-linux", _fileManager->getDeployedFilesStringList());

--- a/Deploy/metafilemanager.cpp
+++ b/Deploy/metafilemanager.cpp
@@ -84,7 +84,7 @@ bool MetaFileManager::createRunScriptLinux(const QString &target) {
             "platforms:$QT_QPA_PLATFORM_PLUGIN_PATH\n"
             "%2"
             "%3\n"
-            "\"$BASE_DIR" + distro.getBinOutDir() + "%1\" \"$@\"";
+            "\"$BASE_DIR" + distro.getBinOutDir() + "%1\" \"$@\"\n";
 
     content = content.arg(QFileInfo(target).fileName());
     int ld_index = DeployCore::find("ld-linux", _fileManager->getDeployedFilesStringList());

--- a/UnitTests/testRes/TestQMLWidgets.sh
+++ b/UnitTests/testRes/TestQMLWidgets.sh
@@ -8,4 +8,4 @@ export QTWEBENGINEPROCESS_PATH="$BASE_DIR"/bin/QtWebEngineProcess
 export QTDIR="$BASE_DIR"
 export QT_QPA_PLATFORM_PLUGIN_PATH="$BASE_DIR"/plugins/platforms:$QT_QPA_PLATFORM_PLUGIN_PATH
 
-"$BASE_DIR"/bin/TestQMLWidgets "$@"
+"$BASE_DIR/bin/TestQMLWidgets" "$@"


### PR DESCRIPTION
The MetaFileManager works correctly on Windows for executable names with spaces in them but on Linux the quote needs to be moved.

New version of PR #380 which is now done on the 1.4 branch and also fixes the unit test.