### PR TITLE
New deploy algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+zip/

--- a/Deploy/configparser.cpp
+++ b/Deploy/configparser.cpp
@@ -1116,7 +1116,7 @@ void ConfigParser::initExtraNames() {
     const auto deployExtraNames = [this](const QStringList& listNamesMasks){
         for (const auto &i : listNamesMasks) {
             if (i.size() > 1) {
-                _config.extraPaths.addtExtraNamesMasks({i});
+                _config.allowedPaths.addtExtraNamesMasks({i});
 
                 QuasarAppUtils::Params::log(i + " added like a file name mask",
                                                    QuasarAppUtils::Info);

--- a/Deploy/configparser.cpp
+++ b/Deploy/configparser.cpp
@@ -608,6 +608,7 @@ QSet<QString> ConfigParser::getQtPathesFromTargets() {
 }
 
 bool ConfigParser::isNeededQt() const {
+
     for (const auto &i: _config.targets()) {
         if (i.isValid() && i.isDependetOfQt()) {
             return true;
@@ -896,6 +897,8 @@ bool ConfigParser::initQmakePrivate(const QString &qmake) {
 }
 
 bool ConfigParser::initQmake() {
+
+
 
     if (!isNeededQt()) {
         QuasarAppUtils::Params::log("deploy only C/C++ libraryes because a qmake is not needed"

--- a/Deploy/configparser.cpp
+++ b/Deploy/configparser.cpp
@@ -1139,7 +1139,7 @@ void ConfigParser::initExtraNames() {
  *
 */
     if (isNeededQt()) {
-        auto libs = DeployCore::Qt3rdpartyLibs( _config.getPlatform(""));
+        auto libs = DeployCore::Qt3rdpartyLibs( _config.getPlatformOfAll());
         deployExtraNames(libs);
     }
 }

--- a/Deploy/configparser.h
+++ b/Deploy/configparser.h
@@ -75,8 +75,8 @@ private:
     bool setQmake(const QString &value);
     bool setQtDir(const QString &value);
 
-    void setExtraPath(const QStringList &value);
-    void setExtraNames(const QStringList &value);
+    void initExtraPath();
+    void initExtraNames();
 
     bool initPlugins();
 

--- a/Deploy/deployconfig.cpp
+++ b/Deploy/deployconfig.cpp
@@ -65,18 +65,19 @@ Platform DeployConfig::getPlatform(const QString& package) const {
         for( auto it = disto.targets().cbegin(); it != disto.targets().cend(); ++it) {
             result = result | _targets.value(*it).getPlatform();
         }
-
-        return result;
     }
 
+    return result;
+}
+
+Platform DeployConfig::getPlatformOfAll() const {
+    Platform result = Platform::UnknownPlatform;
 
     for( auto it = _targets.cbegin(); it != _targets.cend(); ++it) {
         result = result | it.value().getPlatform();
     }
 
     return result;
-
-
 }
 
 const QHash<QString, TargetInfo> &DeployConfig::targets() const {

--- a/Deploy/deployconfig.h
+++ b/Deploy/deployconfig.h
@@ -86,6 +86,13 @@ public:
     QHash<QString, TargetInfo>& targetsEdit();
     QHash<QString, DistroModule>& packagesEdit();
 
+    /**
+     * @brief getPlatform This method return a platform of distribution.
+     *  If you set a pacakge name then this method return platform of package.
+     *  IF package name is empty or not exits then method return platform for all distribution.
+     * @param package This is name of pacakge. Set this parameter to empty string for get a distribution of all pacakges.
+     * @return platform of distribution.
+     */
     Platform getPlatform(const QString& package) const;
 
 private:

--- a/Deploy/deployconfig.h
+++ b/Deploy/deployconfig.h
@@ -42,6 +42,11 @@ public:
     Extra extraPaths;
 
     /**
+     * @brief allowedPaths  - it is list with filters for allowed pathes, files or libraries
+     */
+    Extra allowedPaths;
+
+    /**
      * @brief envirement - envirement for find libraries
      */
     Envirement envirement;

--- a/Deploy/deployconfig.h
+++ b/Deploy/deployconfig.h
@@ -89,11 +89,16 @@ public:
     /**
      * @brief getPlatform This method return a platform of distribution.
      *  If you set a pacakge name then this method return platform of package.
-     *  IF package name is empty or not exits then method return platform for all distribution.
      * @param package This is name of pacakge. Set this parameter to empty string for get a distribution of all pacakges.
      * @return platform of distribution.
      */
     Platform getPlatform(const QString& package) const;
+
+    /**
+     * @brief getPlatformOfAll This method return paltform of all targets of distributuon.
+     * @return platform of all targets.
+     */
+    Platform getPlatformOfAll() const;
 
 private:
 

--- a/Deploy/deploycore.cpp
+++ b/Deploy/deploycore.cpp
@@ -513,12 +513,16 @@ QString DeployCore::getMSVCVersion(MSVCVersion msvc) {
 }
 
 bool DeployCore::isQtLib(const QString &lib) {
-    QFileInfo info((lib));
+    QFileInfo info(lib);
 /*
  * Task https://github.com/QuasarApp/CQtDeployer/issues/422
  * All qt libs need to contains the Qt label.
 */
     bool isQt = isLib(info) && info.fileName().contains("Qt", ONLY_WIN_CASE_INSENSIATIVE);
+
+    if (_config) {
+        isQt = isQt && _config->qtDir.isQt(info.absoluteFilePath());
+    }
 
     if (isQt && QuasarAppUtils::Params::isEndable("noQt") &&
             !QuasarAppUtils::Params::isEndable("qmake")) {

--- a/Deploy/deploycore.cpp
+++ b/Deploy/deploycore.cpp
@@ -512,12 +512,11 @@ QString DeployCore::getMSVCVersion(MSVCVersion msvc) {
 
 bool DeployCore::isQtLib(const QString &lib) {
     QFileInfo info((lib));
-
-    if (_config) {
-        return _config->qtDir.isQt(info.absoluteFilePath());
-    }
-
-    return isLib(info) && info.fileName().contains("Qt", Qt::CaseInsensitive);
+/*
+ * Task https://github.com/QuasarApp/CQtDeployer/issues/422
+ * All qt libs need to contains the Qt label.
+*/
+    return isLib(info) && info.fileName().contains("Qt", ONLY_WIN_CASE_INSENSIATIVE);
 }
 
 bool DeployCore::isExtraLib(const QString &lib) {
@@ -527,7 +526,58 @@ bool DeployCore::isExtraLib(const QString &lib) {
 
 bool DeployCore::isAlienLib(const QString &lib) {
     return lib.contains("/opt/", ONLY_WIN_CASE_INSENSIATIVE) ||
-           lib.contains("/PROGRAM FILES", ONLY_WIN_CASE_INSENSIATIVE);
+            lib.contains("/PROGRAM FILES", ONLY_WIN_CASE_INSENSIATIVE);
+}
+
+QStringList DeployCore::Qt3rdpartyLibs(Platform platform) {
+
+    QStringList result;
+
+    result << QStringList {
+              // Begin SQL LIBS
+              // See task https://github.com/QuasarApp/CQtDeployer/issues/367
+
+              "libpq",
+              "libmysqlclient"
+
+              // End SQL LIBS
+};
+
+    if (platform & Platform::Win) {
+        result << QStringList {
+                  // Qml Gl driver wraper
+                  "d3dcompiler_47",
+                  "libEGL",
+                  "libGLESv2",
+
+                  // gcc runtime libs ow mingw
+                  "libgcc_s_seh",
+                  "libstdc++",
+                  "libwinpthread",
+
+                  // OpenglES libs
+                  "opengl32sw",
+    };
+    }
+
+    if (platform & Platform::Unix) {
+        result << QStringList {
+                  // Begin  Unicode libs
+
+                  "libicudata",
+                  "libicui18n",
+                  "libicuio",
+                  "libicule",
+                  "libiculx",
+                  "libicutest",
+                  "libicutu",
+                  "libicuuc",
+
+                  // End Unicode libs
+    };
+    }
+
+    return result;
 }
 
 QChar DeployCore::getSeparator(int lvl) {

--- a/Deploy/deploycore.cpp
+++ b/Deploy/deploycore.cpp
@@ -135,6 +135,10 @@ LibPriority DeployCore::getLibPriority(const QString &lib) {
         return AlienLib;
     }
 
+    if (isAllowedLib(lib)) {
+        return AllowedLib;
+    }
+
     return SystemLib;
 }
 
@@ -540,6 +544,11 @@ bool DeployCore::isExtraLib(const QString &lib) {
 bool DeployCore::isAlienLib(const QString &lib) {
     return lib.contains("/opt/", ONLY_WIN_CASE_INSENSIATIVE) ||
             lib.contains("/PROGRAM FILES", ONLY_WIN_CASE_INSENSIATIVE);
+}
+
+bool DeployCore::isAllowedLib(const QString &lib) {
+    QFileInfo info(lib);
+    return _config->allowedPaths.contains(info.absoluteFilePath());
 }
 
 QStringList DeployCore::Qt3rdpartyLibs(Platform platform) {

--- a/Deploy/deploycore.cpp
+++ b/Deploy/deploycore.cpp
@@ -199,6 +199,7 @@ void DeployCore::help() {
                  " For gui application sue the deploySystem option "
                  "(on snap version you need to turn on permission)"},
                 {"allPlatforms", "deploy all platforms plugins (big size)."},
+                {"noQt", "Ignore the error of initialize of a qmake. Use only if your application does not use the qt framework."},
 
             }
         },
@@ -327,7 +328,8 @@ QStringList DeployCore::helpKeys() {
         "qifStyle",
         "qifBanner",
         "qifLogo",
-        "allPlatforms"
+        "allPlatforms",
+        "noQt"
     };
 }
 
@@ -516,7 +518,14 @@ bool DeployCore::isQtLib(const QString &lib) {
  * Task https://github.com/QuasarApp/CQtDeployer/issues/422
  * All qt libs need to contains the Qt label.
 */
-    return isLib(info) && info.fileName().contains("Qt", ONLY_WIN_CASE_INSENSIATIVE);
+    bool isQt = isLib(info) && info.fileName().contains("Qt", ONLY_WIN_CASE_INSENSIATIVE);
+
+    if (isQt && QuasarAppUtils::Params::isEndable("noQt") &&
+            !QuasarAppUtils::Params::isEndable("qmake")) {
+        return false;
+    }
+
+    return isQt;
 }
 
 bool DeployCore::isExtraLib(const QString &lib) {

--- a/Deploy/deploycore.h
+++ b/Deploy/deploycore.h
@@ -166,6 +166,15 @@ public:
     static QChar getSeparator(int lvl);
     static bool isAlienLib(const QString &lib);
 
+    /**
+     * @brief QtThreethepartyLibs This method return list of 3rdparty libraryes of qt for selected platform.
+     * @param platform This is OS name.
+     * @return list of 3rdparty libs.
+     * @note This method is hardcode.
+     * @note See Task https://github.com/QuasarApp/CQtDeployer/issues/422 of the CQtDeployer project.
+     */
+    static QStringList Qt3rdpartyLibs(Platform platform);
+
     static char getEnvSeparator();
 
     static LibPriority getLibPriority(const QString &lib);

--- a/Deploy/deploycore.h
+++ b/Deploy/deploycore.h
@@ -56,11 +56,25 @@ enum Platform {
     GeneralFile     = 0x0100
 };
 
+/**
+ * @brief The LibPriority enum This is library priority.
+ * The lower the priority of the topics, the library is the most suitable for distribution.
+ */
 enum LibPriority : int {
+    // ================= General Libraryes
+    /// This is qt libraryes.
     QtLib = 0x0,
+    /// This is user libraryes.
     ExtraLib,
+    /// This is qt 3dParty and user libraryes. (distribution-safe libraries)
+    AllowedLib,
+
+    // ================= System Libraryes
+    /// This is rest of all libraryes (frm system and another).
     SystemLib,
+    /// This is libraryes from another proggram distributions.
     AlienLib,
+    /// This is General Files.
     NotFile = 0xF,
 };
 
@@ -165,6 +179,13 @@ public:
     static bool isExtraLib(const QString &lib);
     static QChar getSeparator(int lvl);
     static bool isAlienLib(const QString &lib);
+
+    /**
+     * @brief isAllowedLib This method checks the library if the library is allowed or not, allowet libraryes is added with extraLibs method.
+     * @param lib This is library fuul path
+     * @return true if lirary is allowed
+     */
+    static bool isAllowedLib(const QString &lib);
 
     /**
      * @brief QtThreethepartyLibs This method return list of 3rdparty libraryes of qt for selected platform.

--- a/Deploy/elf_type.cpp
+++ b/Deploy/elf_type.cpp
@@ -87,7 +87,7 @@ bool ELF::getLibInfo(const QString &lib, LibInfo &info) const {
 
     auto dep = reader.dependencies();
     for (const auto &i : dep) {
-        info.addDependncies(i.toUpper());
+        info.addDependncies(i);
     }
 
     return true;

--- a/Deploy/extracter.cpp
+++ b/Deploy/extracter.cpp
@@ -56,9 +56,8 @@ bool Extracter::extractWebEngine() {
 
             if (cnf->qtDir.getQtPlatform() & Platform::Unix) {
                 webEngeneBin += "/QtWebEngineProcess";
-            } else {
+            } else if (cnf->qtDir.getQtPlatform() & Platform::Win) {
                 webEngeneBin += "/QtWebEngineProcess.exe";
-
             }
 
             auto destWebEngine = cnf->getTargetDir() + "/" + package + cnf->packages()[package].getBinOutDir();

--- a/Deploy/extracter.h
+++ b/Deploy/extracter.h
@@ -56,7 +56,7 @@ private:
     bool extractWebEngine();
 
     /**
-     * @brief angleGLLibs -
+     * @brief angleGLLibs This method return the list of not dependent libs but needed wor working of web Engine (Windows only).
      *  @note see task 398 (https://github.com/QuasarApp/CQtDeployer/issues/398)
      * @return
      */

--- a/Deploy/qtdir.cpp
+++ b/Deploy/qtdir.cpp
@@ -65,3 +65,17 @@ Platform QtDir::getQtPlatform() const {
 void QtDir::setQtPlatform(const Platform &value) {
     qtPlatform = value;
 }
+
+bool QtDir::isQt(QString path) const {
+
+    path =  PathUtils::fixPath(path);
+
+    return
+            (!libs.isEmpty() && path.contains(libs)) ||
+            (!bins.isEmpty() && path.contains(bins)) ||
+    (!libexecs.isEmpty() && path.contains(libexecs)) ||
+    (!plugins.isEmpty() && path.contains(plugins)) ||
+    (!qmls.isEmpty() && path.contains(qmls)) ||
+    (!translations.isEmpty() && path.contains(translations)) ||
+    (!resources.isEmpty() && path.contains(resources));
+}

--- a/Deploy/qtdir.cpp
+++ b/Deploy/qtdir.cpp
@@ -65,17 +65,3 @@ Platform QtDir::getQtPlatform() const {
 void QtDir::setQtPlatform(const Platform &value) {
     qtPlatform = value;
 }
-
-bool QtDir::isQt(QString path) const {
-
-    path =  PathUtils::fixPath(path);
-
-    return
-            (!libs.isEmpty() && path.contains(libs)) ||
-            (!bins.isEmpty() && path.contains(bins)) ||
-    (!libexecs.isEmpty() && path.contains(libexecs)) ||
-    (!plugins.isEmpty() && path.contains(plugins)) ||
-    (!qmls.isEmpty() && path.contains(qmls)) ||
-    (!translations.isEmpty() && path.contains(translations)) ||
-    (!resources.isEmpty() && path.contains(resources));
-}

--- a/Deploy/qtdir.h
+++ b/Deploy/qtdir.h
@@ -35,6 +35,12 @@ public:
     Platform getQtPlatform() const;
     void setQtPlatform(const Platform &value);
 
+    /**
+     * @brief isQt - This method check a path for belonging to QtDirs.
+     * @param path This is cheecked path of library or any qt file.
+     * @return true if object is qt.
+     */
+    bool isQt(QString path) const;
 };
 
 #endif // QTDIR_H

--- a/Deploy/qtdir.h
+++ b/Deploy/qtdir.h
@@ -34,7 +34,6 @@ public:
     void setResources(const QString &value);
     Platform getQtPlatform() const;
     void setQtPlatform(const Platform &value);
-    bool isQt(QString path) const;
 
 };
 

--- a/Deploy/qtdir.h
+++ b/Deploy/qtdir.h
@@ -14,7 +14,7 @@ class DEPLOYSHARED_EXPORT QtDir {
     QString translations;
     QString resources;
 
-    Platform qtPlatform;
+    Platform qtPlatform = UnknownPlatform;
 
 
 public:

--- a/UnitTests/modulesqt515.cpp
+++ b/UnitTests/modulesqt515.cpp
@@ -18,9 +18,11 @@ QSet<QString> ModulesQt515::qtLibs(const QString &distDir) const {
 
 #ifdef Q_OS_WIN
     res -= utils.createTree({
+                                "./" + distDir + "/translations/qtbase_tr.qm",
     });
 #else
     res += utils.createTree({
+                                "./" + distDir + "/translations/qtbase_tr.qm",
     });
 #endif
 
@@ -44,7 +46,9 @@ QSet<QString> ModulesQt515::qmlLibs(const QString &distDir) const {
                                 "./" + distDir + "/qml/QtQuick/Controls.2/Material/VerticalHeaderView.qml",
                                 "./" + distDir + "/qml/QtQuick/Controls.2/Universal/HorizontalHeaderView.qml",
                                 "./" + distDir + "/qml/QtQuick/Controls.2/Universal/VerticalHeaderView.qml",
-                                "./" + distDir + "/qml/QtQuick/Controls.2/VerticalHeaderView.qml"
+                                "./" + distDir + "/qml/QtQuick/Controls.2/VerticalHeaderView.qml",
+                                "./" + distDir + "/qml/QtQuick/Controls.2/designer/InsetSection.qml",
+                                "./" + distDir + "/translations/qtdeclarative_tr.qm",
     });
 #else
     res -= utils.createTree({
@@ -78,7 +82,10 @@ QSet<QString> ModulesQt515::qmlLibs(const QString &distDir) const {
                                 "./" + distDir + "/qml/QtQuick/Controls.2/Material/VerticalHeaderView.qml",
                                 "./" + distDir + "/qml/QtQuick/Controls.2/Universal/HorizontalHeaderView.qml",
                                 "./" + distDir + "/qml/QtQuick/Controls.2/Universal/VerticalHeaderView.qml",
-                                "./" + distDir + "/qml/QtQuick/Controls.2/VerticalHeaderView.qml"
+                                "./" + distDir + "/qml/QtQuick/Controls.2/VerticalHeaderView.qml",
+
+                                "./" + distDir + "/qml/QtQuick/Controls.2/designer/InsetSection.qml",
+                                "./" + distDir + "/translations/qtdeclarative_tr.qm",
                             }
 );
 #endif
@@ -130,7 +137,13 @@ QSet<QString> ModulesQt515::testDistroLibs(const QString &distDir) const {
                                 "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/Material/VerticalHeaderView.qml",
                                 "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/Universal/HorizontalHeaderView.qml",
                                 "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/Universal/VerticalHeaderView.qml",
-                                "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/VerticalHeaderView.qml"
+                                "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/VerticalHeaderView.qml",
+                                "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/designer/InsetSection.qml",
+                                "./" + distDir + "/package2/ZzZ/translations/qtdeclarative_tr.qm",
+                                "./" + distDir + "/package2/ZzZ/translations/qtbase_tr.qm",
+                                "./" + distDir + "/lolTr/qtbase_tr.qm",
+
+
     });
 
 #else
@@ -153,7 +166,12 @@ QSet<QString> ModulesQt515::testDistroLibs(const QString &distDir) const {
                                 "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/Material/VerticalHeaderView.qml",
                                 "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/Universal/HorizontalHeaderView.qml",
                                 "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/Universal/VerticalHeaderView.qml",
-                                "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/VerticalHeaderView.qml"
+                                "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/VerticalHeaderView.qml",
+                                "./" + distDir + "/package2/ZzZ/q/and/q/QtQuick/Controls.2/designer/InsetSection.qml",
+                                "./" + distDir + "/package2/ZzZ/translations/qtdeclarative_tr.qm",
+                                "./" + distDir + "/package2/ZzZ/translations/qtbase_tr.qm",
+                                "./" + distDir + "/lolTr/qtbase_tr.qm",
+
                             });
 
     res -= utils.createTree({
@@ -187,7 +205,11 @@ QSet<QString> ModulesQt515::testOutLibs(const QString &distDir) const {
                                 "./" + distDir + "/q/QtQuick/Controls.2/Material/VerticalHeaderView.qml",
                                 "./" + distDir + "/q/QtQuick/Controls.2/Universal/HorizontalHeaderView.qml",
                                 "./" + distDir + "/q/QtQuick/Controls.2/Universal/VerticalHeaderView.qml",
-                                "./" + distDir + "/q/QtQuick/Controls.2/VerticalHeaderView.qml"
+                                "./" + distDir + "/q/QtQuick/Controls.2/VerticalHeaderView.qml",
+                                "./" + distDir + "/q/QtQuick/Controls.2/designer/InsetSection.qml",
+                                "./" + distDir + "/translations/qtdeclarative_tr.qm",
+                                "./" + distDir + "/translations/qtbase_tr.qm",
+
     });
 #else
     res += utils.createTree({
@@ -221,7 +243,10 @@ QSet<QString> ModulesQt515::testOutLibs(const QString &distDir) const {
                                 "./" + distDir + "/p/wayland-graphics-integration-server/libvulkan-server.so",
                                 "./" + distDir + "/p/wayland-graphics-integration-server/libwayland-eglstream-controller.so",
                                 "./" + distDir + "/p/wayland-graphics-integration-server/libxcomposite-egl.so",
-                                "./" + distDir + "/p/wayland-graphics-integration-server/libxcomposite-glx.so"
+                                "./" + distDir + "/p/wayland-graphics-integration-server/libxcomposite-glx.so",
+                                "./" + distDir + "/q/QtQuick/Controls.2/designer/InsetSection.qml",
+                                "./" + distDir + "/translations/qtdeclarative_tr.qm",
+                                "./" + distDir + "/translations/qtbase_tr.qm",
                             });
 #endif
     return res;

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -1685,7 +1685,8 @@ void deploytest::testIgnore() {
 
     runTestParams({"-bin", bin, "clear" ,
                    "-qmake", qmake,
-                   "-ignoreEnv", TestQtDir + "/lib," + TestQtDir + "/bin," + TestQtDir + "/../../Tools/" },
+                   "-recursiveDepth", "3",
+                   "-ignoreEnv", TestQtDir + "/lib," + TestQtDir + "/bin," + TestQtDir + "/../../Tools" },
                   &comapareTree);
 
 

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -1685,7 +1685,7 @@ void deploytest::testIgnore() {
 
     runTestParams({"-bin", bin, "clear" ,
                    "-qmake", qmake,
-                   "-ignoreEnv", TestQtDir + "/lib," + TestQtDir + "/bin" },
+                   "-ignoreEnv", TestQtDir + "/lib," + TestQtDir + "/bin," + TestQtDir + "/../../Tools/" },
                   &comapareTree);
 
 

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -477,7 +477,12 @@ void deploytest::testExtractLib() {
         QVERIFY(info.getPlatform() == platforms.value(lib));
 
         for (const auto &dep : deb.value(lib)) {
-            bool test = info.getDependncies().contains(dep.toUpper());
+            QString depName = dep;
+            if (info.getPlatform() & Platform::Win) {
+                depName = dep.toUpper();
+            }
+
+            bool test = info.getDependncies().contains(depName);
             QVERIFY(test);
         }
 
@@ -1115,7 +1120,7 @@ void deploytest::testBinDir() {
 
 
     runTestParams({"-binDir", TestBinDir, "clear",
-                   "noCheckRPATH", "noCheckPATH"}, &comapareTree);
+                   "noCheckRPATH", "noCheckPATH", "noQt"}, &comapareTree);
 }
 
 void deploytest::testConfFile() {
@@ -1148,7 +1153,7 @@ void deploytest::testConfFile() {
      "./" + DISTRO_DIR + "/quicknanobrowser.sh"});
 #endif
 
-    runTestParams({"-bin", TestBinDir, "clear" , "noCheckRPATH", "noCheckPATH",
+    runTestParams({"-bin", TestBinDir, "clear" , "noCheckRPATH", "noCheckPATH", "noQt",
                    "-confFile", TestBinDir + "/TestConf.json"}, &comapareTree);
 
 
@@ -1161,11 +1166,11 @@ void deploytest::testConfFile() {
 
 #ifdef Q_OS_UNIX
     runTestParams({"-bin", TestBinDir + "TestOnlyC," + TestBinDir + "QtWidgetsProject," + TestBinDir + "TestQMLWidgets",
-                   "clear", "noCheckRPATH", "noCheckPATH",
+                   "clear", "noCheckRPATH", "noCheckPATH", "noQt",
                    "-confFile", TestBinDir + "/TestConf.json"}, &comapareTree);
 #else
     runTestParams({"-bin", TestBinDir + "TestOnlyC.exe," + TestBinDir + "QtWidgetsProject.exe," + TestBinDir + "TestQMLWidgets.exe",
-                   "clear" , "-libDir", "L:/never/absalut/path", "noCheckPATH",
+                   "clear" , "-libDir", "L:/never/absalut/path", "noCheckPATH", "noQt",
                    "-confFile", TestBinDir + "/TestConf.json"}, &comapareTree);
 #endif
 
@@ -1223,11 +1228,11 @@ void deploytest::testConfFile() {
 
 #ifdef Q_OS_UNIX
     runTestParams({"-bin", TestBinDir + "TestOnlyC," + TestBinDir + "QtWidgetsProject," + TestBinDir + "TestQMLWidgets",
-                   "clear" , "noCheckRPATH", "noCheckPATH",
+                   "clear" , "noCheckRPATH", "noCheckPATH", "noQt",
                    "-confFile", TestBinDir + "/../folder/For/Testing/Deploy/File/TestConf.json"}, &comapareTree);
 #else
     runTestParams({"-bin", TestBinDir + "TestOnlyC.exe," + TestBinDir + "QtWidgetsProject.exe," + TestBinDir + "TestQMLWidgets.exe",
-                   "clear" , "noCheckPATH",
+                   "clear" , "noCheckPATH", "noQt",
                    "-confFile", TestBinDir + "/../folder/For/Testing/Deploy/File/TestConf.json"}, &comapareTree);
 #endif
 
@@ -1687,12 +1692,12 @@ void deploytest::testLibDir() {
     runTestParams({"-bin", bin, "clear" ,
                    "-libDir", extraPath,
                    "-recursiveDepth", "5",
-                   "noCheckRPATH, noCheckPATH"}, &comapareTree, {}, true);
+                   "noCheckRPATH, noCheckPATH", "noQt"}, &comapareTree, {}, true);
 
     runTestParams({"-bin", bin, "clear" ,
                    "-targetDir", "./" + DISTRO_DIR + "2",
                    "-extraLibs", "stdc,gcc",
-                   "noCheckRPATH, noCheckPATH"}, &comapareTreeExtraLib, {}, true);
+                   "noCheckRPATH, noCheckPATH", "noQt"}, &comapareTreeExtraLib, {}, true);
 
     //task #258
     //https://github.com/QuasarApp/CQtDeployer/issues/258
@@ -1725,7 +1730,7 @@ void deploytest::testLibDir() {
 #endif
     runTestParams({"-bin", bin, "clear" ,
                    "-libDir", extraPath,
-                   "noCheckRPATH, noCheckPATH"}, &comapareTreeExtraLib, {}, true);
+                   "noCheckRPATH, noCheckPATH", "noQt"}, &comapareTreeExtraLib, {}, true);
 
     QDir(extraPath).removeRecursively();
 

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -1598,7 +1598,8 @@ void deploytest::testIgnore() {
 
     runTestParams({"-bin", bin, "clear" ,
                    "-qmake", qmake,
-                   "-ignoreEnv", TestQtDir + "/lib," + TestQtDir + "/bin" }, &comapareTree);
+                   "-ignoreEnv", TestQtDir + "/lib," + TestQtDir + "/bin" },
+                  &comapareTree);
 
 
     comapareTree = TestModule.qtLibs() - removeTree;

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -80,7 +80,6 @@ private slots:
     void testStrip();
     void testExtractLib();
     void testRelativeLink();
-    void testCheckQt();
 
     void testQmlExtrct();
     void testSetTargetDir();
@@ -828,92 +827,6 @@ void deploytest::testRelativeLink() {
             QVERIFY(false);
 
     }
-}
-
-void deploytest::testCheckQt() {
-
-    Deploy *deployer = new Deploy();
-    QuasarAppUtils::Params::parseParams({"-binDir", TestBinDir, "clear",
-                                         "noCheckRPATH", "noCheckPATH"});
-    QVERIFY(deployer->prepare());
-
-
-    auto cases = QList<QPair<QString, bool>>{
-        {TestQtDir + "/", false},
-        {TestQtDir + "", false},
-        {TestQtDir + "/bin/file1", false},
-        {TestQtDir + "/lib/file12", false},
-        {TestQtDir + "/resurces/file13", false},
-        {TestQtDir + "/libexec/f", false},
-        {TestQtDir + "/mkspecs", false},
-        {TestQtDir + "/qml", false},
-        {TestQtDir + "/plugins", false},
-        {TestQtDir + "/file", false},
-
-        {TestQtDir + "\\", false},
-        {TestQtDir + "", false},
-        {TestQtDir + "\\bin\\file1", false},
-        {TestQtDir + "\\lib\\file12", false},
-        {TestQtDir + "\\resurces\\file13", false},
-        {TestQtDir + "\\libexec\\f", false},
-        {TestQtDir + "\\mkspecs", false},
-        {TestQtDir + "\\qml", false},
-        {TestQtDir + "\\plugins", false},
-        {TestQtDir + "\\file", false},
-
-    };
-
-    for (const auto &i: cases) {
-        QVERIFY(DeployCore::isQtLib(i.first) == i.second);
-    }
-    delete deployer;
-
-#ifdef Q_OS_UNIX
-    QString bin = TestBinDir + "TestQMLWidgets";
-    QString qmake = TestQtDir + "bin/qmake";
-
-#else
-    QString bin = TestBinDir + "TestQMLWidgets.exe";
-    QString qmake = TestQtDir + "bin/qmake.exe";
-#endif
-
-    deployer = new Deploy();
-    QuasarAppUtils::Params::parseParams({"-bin", bin, "clear" ,
-                                         "-qmake", qmake,
-                                         "-qmlDir", TestBinDir + "/../TestQMLWidgets"});
-    QVERIFY(deployer->prepare());
-
-
-    cases = QList<QPair<QString, bool>>{
-        {TestQtDir + "/", false},
-        {TestQtDir + "", false},
-        {TestQtDir + "/bin/file1", true},
-        {TestQtDir + "/lib/file12", true},
-        {TestQtDir + "/resources/file13", true},
-        {TestQtDir + "/libexec/f", true},
-        {TestQtDir + "/mkspecs", false},
-        {TestQtDir + "/qml", true},
-        {TestQtDir + "/plugins", true},
-        {TestQtDir + "/file", false},
-
-        {TestQtDir + "\\", false},
-        {TestQtDir + "", false},
-        {TestQtDir + "\\bin\\file1", true},
-        {TestQtDir + "\\lib\\file12", true},
-        {TestQtDir + "\\resources\\file13", true},
-        {TestQtDir + "\\libexec\\f", true},
-        {TestQtDir + "\\mkspecs", false},
-        {TestQtDir + "\\qml", true},
-        {TestQtDir + "\\plugins", true},
-        {TestQtDir + "\\file", false},
-
-    };
-
-    for (const auto &i: cases) {
-        QVERIFY(DeployCore::isQtLib(i.first) == i.second);
-    }
-
-    delete deployer;
 }
 
 void deploytest::testSetTargetDir() {

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -1615,6 +1615,9 @@ void deploytest::testIgnore() {
     {
                     "./" + DISTRO_DIR + "/qt.conf",
                     "./" + DISTRO_DIR + "/QtWidgetsProject.exe",
+                    "./" + DISTRO_DIR + "/libgcc_s_seh-1.dll",
+                    "./" + DISTRO_DIR + "/libstdc++-6.dll",
+                    "./" + DISTRO_DIR + "/libwinpthread-1.dll"
 
                 });
 
@@ -1630,13 +1633,6 @@ void deploytest::testIgnore() {
 #else
         QString bin = TestBinDir + "QtWidgetsProject.exe";
         QString qmake = TestQtDir + "bin/qmake.exe";
-
-        comapareTree += utils.createTree(
-        {
-                        "./" + DISTRO_DIR + "/libgcc_s_seh-1.dll",
-                        "./" + DISTRO_DIR + "/libstdc++-6.dll",
-                        "./" + DISTRO_DIR + "/libwinpthread-1.dll"
-                    });
 
 #endif
     }

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -839,7 +839,7 @@ void deploytest::testCheckQt() {
 
     Deploy *deployer = new Deploy();
     QuasarAppUtils::Params::parseParams({"-binDir", TestBinDir, "clear",
-                                         "noCheckRPATH", "noCheckPATH"});
+                                         "noCheckRPATH", "noCheckPATH", "noQt"});
     QVERIFY(deployer->prepare());
 
 

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -80,6 +80,7 @@ private slots:
     void testStrip();
     void testExtractLib();
     void testRelativeLink();
+    void testCheckQt();
 
     void testQmlExtrct();
     void testSetTargetDir();
@@ -832,6 +833,92 @@ void deploytest::testRelativeLink() {
             QVERIFY(false);
 
     }
+}
+
+void deploytest::testCheckQt() {
+
+    Deploy *deployer = new Deploy();
+    QuasarAppUtils::Params::parseParams({"-binDir", TestBinDir, "clear",
+                                         "noCheckRPATH", "noCheckPATH"});
+    QVERIFY(deployer->prepare());
+
+
+    auto cases = QList<QPair<QString, bool>>{
+        {TestQtDir + "/", false},
+        {TestQtDir + "", false},
+        {TestQtDir + "/bin/file1", false},
+        {TestQtDir + "/lib/file12", false},
+        {TestQtDir + "/resurces/file13", false},
+        {TestQtDir + "/libexec/f", false},
+        {TestQtDir + "/mkspecs", false},
+        {TestQtDir + "/qml", false},
+        {TestQtDir + "/plugins", false},
+        {TestQtDir + "/file", false},
+
+        {TestQtDir + "\\", false},
+        {TestQtDir + "", false},
+        {TestQtDir + "\\bin\\file1", false},
+        {TestQtDir + "\\lib\\file12", false},
+        {TestQtDir + "\\resurces\\file13", false},
+        {TestQtDir + "\\libexec\\f", false},
+        {TestQtDir + "\\mkspecs", false},
+        {TestQtDir + "\\qml", false},
+        {TestQtDir + "\\plugins", false},
+        {TestQtDir + "\\file", false},
+
+    };
+
+    for (const auto &i: cases) {
+        QVERIFY(DeployCore::isQtLib(i.first) == i.second);
+    }
+    delete deployer;
+
+#ifdef Q_OS_UNIX
+    QString bin = TestBinDir + "TestQMLWidgets";
+    QString qmake = TestQtDir + "bin/qmake";
+
+#else
+    QString bin = TestBinDir + "TestQMLWidgets.exe";
+    QString qmake = TestQtDir + "bin/qmake.exe";
+#endif
+
+    deployer = new Deploy();
+    QuasarAppUtils::Params::parseParams({"-bin", bin, "clear" ,
+                                         "-qmake", qmake,
+                                         "-qmlDir", TestBinDir + "/../TestQMLWidgets"});
+    QVERIFY(deployer->prepare());
+
+
+    cases = QList<QPair<QString, bool>>{
+        {TestQtDir + "/", false},
+        {TestQtDir + "", false},
+        {TestQtDir + "/bin/file1", true},
+        {TestQtDir + "/lib/file12", true},
+        {TestQtDir + "/resources/file13", true},
+        {TestQtDir + "/libexec/f", true},
+        {TestQtDir + "/mkspecs", false},
+        {TestQtDir + "/qml", true},
+        {TestQtDir + "/plugins", true},
+        {TestQtDir + "/file", false},
+
+        {TestQtDir + "\\", false},
+        {TestQtDir + "", false},
+        {TestQtDir + "\\bin\\file1", true},
+        {TestQtDir + "\\lib\\file12", true},
+        {TestQtDir + "\\resources\\file13", true},
+        {TestQtDir + "\\libexec\\f", true},
+        {TestQtDir + "\\mkspecs", false},
+        {TestQtDir + "\\qml", true},
+        {TestQtDir + "\\plugins", true},
+        {TestQtDir + "\\file", false},
+
+    };
+
+    for (const auto &i: cases) {
+        QVERIFY(DeployCore::isQtLib(i.first) == i.second);
+    }
+
+    delete deployer;
 }
 
 void deploytest::testSetTargetDir() {

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -847,8 +847,8 @@ void deploytest::testCheckQt() {
         {TestQtDir + "/", false},
         {TestQtDir + "", false},
         {TestQtDir + "/bin/file1", false},
-        {TestQtDir + "/lib/file12", false},
-        {TestQtDir + "/resurces/file13", false},
+        {TestQtDir + "/lib/file12.so", false},
+        {TestQtDir + "/resurces/file13.dll", false},
         {TestQtDir + "/libexec/f", false},
         {TestQtDir + "/mkspecs", false},
         {TestQtDir + "/qml", false},
@@ -860,8 +860,8 @@ void deploytest::testCheckQt() {
         {TestQtDir + "\\bin\\file1", false},
         {TestQtDir + "\\lib\\file12", false},
         {TestQtDir + "\\resurces\\file13", false},
-        {TestQtDir + "\\libexec\\f", false},
-        {TestQtDir + "\\mkspecs", false},
+        {TestQtDir + "\\libexec\\f.so", false},
+        {TestQtDir + "\\mkspecs.dll", false},
         {TestQtDir + "\\qml", false},
         {TestQtDir + "\\plugins", false},
         {TestQtDir + "\\file", false},
@@ -892,30 +892,34 @@ void deploytest::testCheckQt() {
     cases = QList<QPair<QString, bool>>{
         {TestQtDir + "/", false},
         {TestQtDir + "", false},
-        {TestQtDir + "/bin/file1", true},
-        {TestQtDir + "/lib/file12", true},
-        {TestQtDir + "/resources/file13", true},
-        {TestQtDir + "/libexec/f", true},
+        {TestQtDir + "/bin/file1", false},
+        {TestQtDir + "/lib/file12", false},
+        {TestQtDir + "/bin/file1Qt.so", true},
+        {TestQtDir + "/lib/file12", false},
+        {TestQtDir + "/resources/Qtfile13.so", true},
+        {TestQtDir + "/libexec/Qtf.dll", true},
         {TestQtDir + "/mkspecs", false},
-        {TestQtDir + "/qml", true},
-        {TestQtDir + "/plugins", true},
+        {TestQtDir + "/qml", false},
+        {TestQtDir + "/plugins", false},
         {TestQtDir + "/file", false},
 
         {TestQtDir + "\\", false},
         {TestQtDir + "", false},
-        {TestQtDir + "\\bin\\file1", true},
-        {TestQtDir + "\\lib\\file12", true},
-        {TestQtDir + "\\resources\\file13", true},
-        {TestQtDir + "\\libexec\\f", true},
+        {TestQtDir + "\\bin\\Qtfile1.dll", true},
+        {TestQtDir + "\\lib\\file12", false},
+        {TestQtDir + "\\resources\\fileQt13.dll", true},
+        {TestQtDir + "\\libexec\\fQt", false},
         {TestQtDir + "\\mkspecs", false},
-        {TestQtDir + "\\qml", true},
-        {TestQtDir + "\\plugins", true},
+        {TestQtDir + "\\qml", false},
+        {TestQtDir + "\\plugins", false},
         {TestQtDir + "\\file", false},
 
     };
 
     for (const auto &i: cases) {
-        QVERIFY(DeployCore::isQtLib(i.first) == i.second);
+        auto dexription = QString("The isQtLib(%0) function should be return %1").arg(
+                    i.first).arg(i.second);
+        QVERIFY2(DeployCore::isQtLib(i.first) == i.second, dexription.toLatin1().data());
     }
 
     delete deployer;


### PR DESCRIPTION
Set new algorithm of deployment qt libs.

1. Check targets of Qt depends.
 Change isQt. mow this method check only name of library.
2. if the Distribution dependet of qt then add toextraNames list of 3dParty libs of qt.

* fix #422 
* fix #367
* fix #371  