### PR TITLE
Use STL header <set> instead of the internal header <bits/stl_set.h>

### DIFF
--- a/Deploy/pe_type.cpp
+++ b/Deploy/pe_type.cpp
@@ -14,7 +14,7 @@
 #include <parser-library/parse.h>
 #include <quasarapp.h>
 
-#include <bits/stl_set.h>
+#include <set>
 
 namespace peparse {
 


### PR DESCRIPTION
Hi, thank you for your great work. CQtDeployer made it easy for me to find the dll files that the Qt program depends on.

## About the changes

I was attempting to build this program with MSVC. I found the header file `<bits/stl_set.h>` was used directly so MSVC failed. It would be better if you use the standard library header `<set>`.

Well, I know that if I continue to use MSVC, other errors will occur. In order not to break existing code, I only changed the header file, and will not commit any other code related to MSVC build recently.

## Test failed

> ## Code Guideline
> 
> 12. Before pushing the code, be sure to run the tests.
> 
> *from: https://github.com/QuasarApp/CQtDeployer/blob/d0fd4f93966b1d6b3d77f65ba4e3ea3187119f36/CONTRIBUTING.md#code-guideline*

I'm using Qt 5.15.0 mingw810_64 and I failed one test before and after changing the header file, please see #481 .

I'm sorry I can't find the reason. Could you please give me some suggestions? Thank you in advance.
