### PR TITLE
Fix #396 "add stdc++ lib into ignore list"

### DIFF
--- a/Deploy/configparser.cpp
+++ b/Deploy/configparser.cpp
@@ -884,6 +884,7 @@ void ConfigParser::initIgnoreList()
         };
 
         _config.ignoreList.addRule(addRuleUnix("libc"));
+        _config.ignoreList.addRule(addRuleUnix("libstdc++"));
         _config.ignoreList.addRule(addRuleUnix("ld-"));
         _config.ignoreList.addRule(addRuleUnix("libpthread"));
         _config.ignoreList.addRule(addRuleUnix("libm"));
@@ -897,7 +898,7 @@ void ConfigParser::initIgnoreList()
         _config.ignoreList.addRule(addRuleUnix("libBrokenLocale"));
         _config.ignoreList.addRule(addRuleUnix("libSegFault"));
         _config.ignoreList.addRule(addRuleUnix("libanl"));
-        _config.ignoreList.addRule(addRuleUnix("libcrypt"));
+        _config.ignoreList.addRule(addRuleUnix("libcrypt.so"));
         _config.ignoreList.addRule(addRuleUnix("/gconv/"));
         _config.ignoreList.addRule(addRuleUnix("libnss"));
     }


### PR DESCRIPTION
All linux systems have a stdc++ library. so this library no needed in the distribution of a deployed application.
Fix #396