### PR TITLE
[WIP] Process Qt Bin path correctly to find MSVC redistributable packages

### DIFF
--- a/Deploy/deploycore.cpp
+++ b/Deploy/deploycore.cpp
@@ -478,12 +478,12 @@ MSVCVersion DeployCore::getMSVC(const QString &_qtBin) {
         return static_cast<MSVCVersion>(res);
     }
 
-    if (!msvcPath.contains("msvc")) {
+    if (!msvcPath.contains("MSVC")) {
         QuasarAppUtils::Params::log("vcredis not defined");
         return static_cast<MSVCVersion>(res);
     }
 
-    auto base = msvcPath.mid(msvcPath.indexOf("msvc"), 11);
+    auto base = msvcPath.mid(msvcPath.indexOf("MSVC"), 11);
     auto version = base.mid(4 , 4);
     auto type = base.right(2);
 
@@ -538,13 +538,13 @@ QString DeployCore::getVCredist(const QString &_qtbinDir) {
 }
 
 QString DeployCore::getMSVCName(MSVCVersion msvc) {
-    if (msvc | MSVCVersion::MSVC_13) {
+    if (msvc & MSVCVersion::MSVC_13) {
         return "msvc2013";
-    } else if (msvc | MSVCVersion::MSVC_15) {
+    } else if (msvc & MSVCVersion::MSVC_15) {
         return "msvc2015";
-    } else if (msvc | MSVCVersion::MSVC_17) {
+    } else if (msvc & MSVCVersion::MSVC_17) {
         return "msvc2017";
-    } else if (msvc | MSVCVersion::MSVC_19) {
+    } else if (msvc & MSVCVersion::MSVC_19) {
         return "msvc2019";
     }
 
@@ -552,9 +552,9 @@ QString DeployCore::getMSVCName(MSVCVersion msvc) {
 }
 
 QString DeployCore::getMSVCVersion(MSVCVersion msvc) {
-    if (msvc | MSVCVersion::MSVC_x32) {
+    if (msvc & MSVCVersion::MSVC_x32) {
         return "x86";
-    } else if (msvc | MSVCVersion::MSVC_x64) {
+    } else if (msvc & MSVCVersion::MSVC_x64) {
         return "x64";
     }
 

--- a/Deploy/deploycore.cpp
+++ b/Deploy/deploycore.cpp
@@ -515,6 +515,11 @@ MSVCVersion DeployCore::getMSVC(const QString &_qtBin) {
 QString DeployCore::getVCredist(const QString &_qtbinDir) {
     auto msvc = getMSVC(_qtbinDir);
 
+    if (msvc == MSVCVersion::MSVC_Unknown) {
+        QuasarAppUtils::Params::log("unknown msvc");
+        return "";
+    }
+
     QDir dir = _qtbinDir;
 
     if (!(dir.cdUp() && dir.cdUp() && dir.cdUp() && dir.cd("vcredist"))) {
@@ -526,6 +531,16 @@ QString DeployCore::getVCredist(const QString &_qtbinDir) {
 
     auto name = getMSVCName(msvc);
     auto version = getMSVCVersion(msvc);
+
+    if (name == "") {
+        QuasarAppUtils::Params::log("msvc name unrecognized");
+        return "";
+    }
+
+    if (version == "") {
+        QuasarAppUtils::Params::log("msvc version unrecognized");
+        return "";
+    }
 
     for (const auto &info: infoList) {
         auto file = info.fileName();

--- a/Deploy/deploycore.cpp
+++ b/Deploy/deploycore.cpp
@@ -485,7 +485,7 @@ MSVCVersion DeployCore::getMSVC(const QString &_qtBin) {
 
     auto base = msvcPath.mid(msvcPath.indexOf("MSVC"), 11);
     auto version = base.mid(4 , 4);
-    auto type = base.right(2);
+    auto type = base.mid(8, 3);
 
     if (version == "2013") {
         res |= MSVC_13;
@@ -500,10 +500,12 @@ MSVCVersion DeployCore::getMSVC(const QString &_qtBin) {
         res |= MSVC_19;
     }
 
-    if (type == "32") {
+    if (type == "") {
+        // e.g., "MSVC2015", "MSVC2017" or "MSVC2019"
         res |= MSVC_x32;
     }
-    else if (type == "64") {
+    else if (type == "_64") {
+        // e.g., "MSVC2013_64", "MSVC2015_64", "MSVC2017_64" or "MSVC2019_64"
         res |= MSVC_x64;
     }
 

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -499,10 +499,10 @@ void deploytest::testExtractLib() {
 }
 
 void deploytest::testMSVC() {
-    QString testPath = "./Qt/5.11.2/msvc2017_64/bin/";
+    QString testPath = "./QT/5.11.2/MSVC2017_64/BIN/";
 
     QDir d;
-    QDir oldDir("./Qt");
+    QDir oldDir("./QT");
     oldDir.removeRecursively();
     QVERIFY(d.mkpath(testPath));
 
@@ -512,7 +512,7 @@ void deploytest::testMSVC() {
     QVERIFY(msvc & MSVCVersion::MSVC_17);
     QVERIFY(msvc & MSVCVersion::MSVC_x64);
 
-    QDir dir("./Qt");
+    QDir dir("./QT");
     dir.removeRecursively();
 
 


### PR DESCRIPTION
Fixed #495 .

## Why it occurred

`QtDir::setBins(const QString&)` uses `PathUtils::fixPath(const QString&)` to convert all characters in the path to uppercase on Windows.

https://github.com/QuasarApp/CQtDeployer/blob/d7b48f3529f881f40f30ed1a7b8c21feaab97c22/Deploy/qtdir.cpp#L31-L34

https://github.com/QuasarApp/CQtDeployer/blob/d7b48f3529f881f40f30ed1a7b8c21feaab97c22/Deploy/pathutils.cpp#L101-L108

<br>

So, `DeployCore::getVCredist(const QString&)` receives the Qt bin path in all uppercase (like `C:/QT/5.15.0/MSVC2019_64/BIN`) from `Extracter::deployMSVC()`.

https://github.com/QuasarApp/CQtDeployer/blob/d7b48f3529f881f40f30ed1a7b8c21feaab97c22/Deploy/extracter.cpp#L29-L40

https://github.com/QuasarApp/CQtDeployer/blob/d7b48f3529f881f40f30ed1a7b8c21feaab97c22/Deploy/qtdir.cpp#L27-L30

<br>

Then, `DeployCore::getMSVC(const QString&)` receives the Qt bin path in all uppercase from `DeployCore::getVCredist(const QString&)`, but he has not processed `msvcPath` correctly ("msvc" vs. "MSVC" in `C:/QT/5.15.0/MSVC2019_64`).

https://github.com/QuasarApp/CQtDeployer/blob/d7b48f3529f881f40f30ed1a7b8c21feaab97c22/Deploy/deploycore.cpp#L513-L515

https://github.com/QuasarApp/CQtDeployer/blob/d7b48f3529f881f40f30ed1a7b8c21feaab97c22/Deploy/deploycore.cpp#L481-L489

<br>

And, neither `DeployCore::getMSVCName(MSVCVersion)` nor `DeployCore::getMSVCVersion(MSVCVersion)` uses the correct operator for matching, so `DeployCore::getVCredist(const QString&)` cannot receive the correct result and find the correct MSVC redist installer.

https://github.com/QuasarApp/CQtDeployer/blob/d7b48f3529f881f40f30ed1a7b8c21feaab97c22/Deploy/deploycore.cpp#L525-L527

https://github.com/QuasarApp/CQtDeployer/blob/d7b48f3529f881f40f30ed1a7b8c21feaab97c22/Deploy/deploycore.cpp#L540-L563

Finally, it wants to copy the installer whose name contains "msvc2013" and "x86", but this is not what I expected.

So, it's broken.

## Why tests passed

The test `deploytest::testMSVC()` has not covered all possible cases.

https://github.com/QuasarApp/CQtDeployer/blob/d7b48f3529f881f40f30ed1a7b8c21feaab97c22/UnitTests/tst_deploytest.cpp#L501-L520

In addition, I think more tests could be added:
1. Test `DeployCore::getVCredist(const QString&)` by creating some dummy files as MSVC redist installer (For example, zero byte file "vcredist_msvc2019_x64.exe").
2. Test both `DeployCore::getMSVCName(MSVCVersion)` and `DeployCore::getMSVCVersion(MSVCVersion)` with all possible values.

## If changes applied

stdout:

```console
...
Info: try deploy msvc
Info: copy :C:/QT/vcredist/vcredist_msvc2019_x64.exe
Info: deploy done!
...
```

Files:

```console
.>tree /A /F
.
|   qt.conf
|   Qt5Core.dll
|   Qt5DBus.dll
|   Qt5Gui.dll
|   Qt5Svg.dll
|   Qt5Widgets.dll
|   test-CQD-1.bat
|   test-CQD-1.exe
|   vcredist_msvc2019_x64.exe <--- hey!
|
...
```

<br>

However, test `deploytest::testMSVC()` will fail, so I need your help to write some new tests.
