### PR TITLE
Hide cmd on windows.

### DIFF
--- a/Deploy/metafilemanager.cpp
+++ b/Deploy/metafilemanager.cpp
@@ -44,12 +44,14 @@ bool MetaFileManager::createRunScriptWindows(const QString &target) {
                 "SET CQT_PKG_ROOT=%BASE_DIR%\n"
 
                 "%3\n"
-                "start \"%0\" /B \"%BASE_DIR%" + distro.getBinOutDir() + "%1\" %2 \n";
+                "start \"%0\" %4 \"%BASE_DIR%" + distro.getBinOutDir() + "%1\" %2 \n";
 
         content = content.arg(targetInfo.baseName(), targetInfo.fileName(), "%*");
         content = content.arg(generateCustoScriptBlok(true));
 
         content = QDir::toNativeSeparators(content);
+        content = content.arg("/B");
+
     }
 
     QString fname = DeployCore::_config->getTargetDir(target) + QDir::separator() + targetInfo.baseName()+ ".bat";

--- a/Deploy/metafilemanager.cpp
+++ b/Deploy/metafilemanager.cpp
@@ -46,7 +46,7 @@ bool MetaFileManager::createRunScriptWindows(const QString &target) {
                 "%3\n"
                 "start \"%0\" /B \"%BASE_DIR%" + distro.getBinOutDir() + "%1\" %2 \n";
 
-        content = content.arg(targetInfo.baseName(), targetInfo.fileName()).arg("%*");
+        content = content.arg(targetInfo.baseName(), targetInfo.fileName(), "%*");
         content = content.arg(generateCustoScriptBlok(true));
 
         content = QDir::toNativeSeparators(content);

--- a/Deploy/metafilemanager.cpp
+++ b/Deploy/metafilemanager.cpp
@@ -43,10 +43,10 @@ bool MetaFileManager::createRunScriptWindows(const QString &target) {
                 "SET PATH=%BASE_DIR%" + distro.getLibOutDir() + ";%PATH%\n"
                 "SET CQT_PKG_ROOT=%BASE_DIR%\n"
 
-                "%2\n"
-                "call \"%BASE_DIR%" + distro.getBinOutDir() + "%0\" %1 \n";
+                "%3\n"
+                "start \"%0\" /B \"%BASE_DIR%" + distro.getBinOutDir() + "%1\" %2 \n";
 
-        content = content.arg(targetInfo.fileName()).arg("%*");
+        content = content.arg(targetInfo.baseName(), targetInfo.fileName()).arg("%*");
         content = content.arg(generateCustoScriptBlok(true));
 
         content = QDir::toNativeSeparators(content);

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -2634,6 +2634,8 @@ void deploytest::testOutDirs() {
     runScript = file.readAll();
     file.close();
 
+    qDebug() << "runScript =" << runScript;
+
     QVERIFY(runScript.contains("SET BASE_DIR=%~dp0"));
     QVERIFY(runScript.contains("SET PATH=%BASE_DIR%\\lolLib\\;%PATH%"));
     QVERIFY(runScript.contains("start \"TestQMLWidgets\" /B \"%BASE_DIR%\\lol\\TestQMLWidgets.exe\" %*"));

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -2636,7 +2636,7 @@ void deploytest::testOutDirs() {
 
     QVERIFY(runScript.contains("SET BASE_DIR=%~dp0"));
     QVERIFY(runScript.contains("SET PATH=%BASE_DIR%\\lolLib\\;%PATH%"));
-    QVERIFY(runScript.contains("start "TestQMLWidgets" /B \"%BASE_DIR%\\lol\\TestQMLWidgets.exe\" %*"));
+    QVERIFY(runScript.contains("start \"TestQMLWidgets\" /B \"%BASE_DIR%\\lol\\TestQMLWidgets.exe\" %*"));
 
 
 #endif

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -2636,7 +2636,7 @@ void deploytest::testOutDirs() {
 
     QVERIFY(runScript.contains("SET BASE_DIR=%~dp0"));
     QVERIFY(runScript.contains("SET PATH=%BASE_DIR%\\lolLib\\;%PATH%"));
-    QVERIFY(runScript.contains("call \"%BASE_DIR%\\lol\\TestQMLWidgets.exe\" %*"));
+    QVERIFY(runScript.contains("start "TestQMLWidgets" /B \"%BASE_DIR%\\lol\\TestQMLWidgets.exe\" %*"));
 
 
 #endif


### PR DESCRIPTION
Description:
If you run the installed application through a shortcut or bat file, the console window will be blank until the application is closed. In most cases, the user does not want to see it when launching the application using a shortcut.

These changes should fix this problem.

now the command is used to launch the application: 

``` bat
start "MyAppTitle" /B "bin/MyExecutable.exe" *%
```