### PR TITLE
Generate buildLog.log in current working directory

### DIFF
--- a/test.pri
+++ b/test.pri
@@ -15,7 +15,7 @@ deployTest.commands = $$DEPLOYER -bin $$exec clear -qmake $$QMAKE_BIN -targetDir
 
 !android:test.depends = deployTest
 unix:!android:test.commands = $$PWD/deployTests/UnitTests.sh -maxwarnings 100000
-win32:test.commands = $$PWD/deployTests/UnitTests.exe -maxwarnings 100000 -o $$PWD/buildLog.log
+win32:test.commands = $$PWD/deployTests/UnitTests.exe -maxwarnings 100000 -o buildLog.log
 
 contains(QMAKE_HOST.os, Linux):{
     win32:test.commands =


### PR DESCRIPTION
Hi. I usually build this program in another place to keep source code directory clean (like Qt Creator's shadow building). Everything works fine but the test result file buildLog.log is not generated in my current working directory (that is, the build directory), so I made this change.
