### PR TITLE
Use QString::SkipEmptyParts in Qt 5.13.x or earlier and Qt::SkipEmptyParts in Qt 5.14.0 or later

### DIFF
--- a/Deploy/defines.h
+++ b/Deploy/defines.h
@@ -9,7 +9,7 @@
 #define DEFINES_H
 #include <QtGlobal>
 
-#if QT_VERSION > QT_VERSION_CHECK(5, 13, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
             #define splitbehavior Qt::SkipEmptyParts
 #else
             #define splitbehavior QString::SkipEmptyParts

--- a/Deploy/filemanager.cpp
+++ b/Deploy/filemanager.cpp
@@ -447,7 +447,7 @@ QString FileManager::changeDistanation(const QString& absalutePath,
                                        QString basePath,
                                        int depch) {
 
-#if QT_VERSION > QT_VERSION_CHECK(5, 13, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     auto prefixes = absalutePath.split(QRegExp("[\\/]"), Qt::SkipEmptyParts);
 #else
     auto prefixes = absalutePath.split(QRegExp("[\\/]"), QString::SkipEmptyParts);

--- a/Deploy/filemanager.cpp
+++ b/Deploy/filemanager.cpp
@@ -447,11 +447,7 @@ QString FileManager::changeDistanation(const QString& absalutePath,
                                        QString basePath,
                                        int depch) {
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-    auto prefixes = absalutePath.split(QRegExp("[\\/]"), Qt::SkipEmptyParts);
-#else
-    auto prefixes = absalutePath.split(QRegExp("[\\/]"), QString::SkipEmptyParts);
-#endif
+    auto prefixes = absalutePath.split(QRegExp("[\\/]"), splitbehavior);
     depch = std::min(depch, prefixes.size());
     while (depch) {
         auto index = prefixes.size() - depch;


### PR DESCRIPTION
Checklist:

- [x] Use `Qt::SkipEmptyParts` only in Qt 5.14.0 or later.
- [x] Use macro `splitbehavior` to reduce repetition.

Tested with Qt 5.12.10, 5.13.2, 5.14.0, 5.14.2, 5.15.0, 5.15.1 and 5.15.2 (all MinGW x64).
