### PR TITLE
Allow testing on still supported versions and completely disable it on older versions

### DIFF
--- a/CQtDeployer.pro
+++ b/CQtDeployer.pro
@@ -8,7 +8,7 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
-lessThan(QT_MAJOR_VERSION, 6):lessThan(QT_MINOR_VERSION, 14) {
+lessThan(QT_MAJOR_VERSION, 6):lessThan(QT_MINOR_VERSION, 12) {
     message(Tests is disabled!)
     DEFINES += WITHOUT_TESTS
 }

--- a/CQtDeployer.pro
+++ b/CQtDeployer.pro
@@ -9,7 +9,7 @@ TEMPLATE = subdirs
 CONFIG += ordered
 
 lessThan(QT_MAJOR_VERSION, 6):lessThan(QT_MINOR_VERSION, 12) {
-    message(Tests is disabled!)
+    warning("Tests are only enabled on Qt 5.12.0 or later version. You are using $$[QT_VERSION].")
     DEFINES += WITHOUT_TESTS
 }
 

--- a/CQtDeployer.pro
+++ b/CQtDeployer.pro
@@ -35,6 +35,8 @@ lessThan(QT_MAJOR_VERSION, 6):lessThan(QT_MINOR_VERSION, 12) {
                tests/TestQMLWidgets \
                tests/quicknanobrowser \
                tests/webui
+    } else {
+        include($$PWD/test.pri)
     }
 
     CQtDeployer.depends=QuasarAppLib
@@ -52,5 +54,4 @@ lessThan(QT_MAJOR_VERSION, 6):lessThan(QT_MINOR_VERSION, 12) {
 
 
 }
-    include($$PWD/test.pri)
 

--- a/CQtDeployer.pro
+++ b/CQtDeployer.pro
@@ -35,8 +35,6 @@ lessThan(QT_MAJOR_VERSION, 6):lessThan(QT_MINOR_VERSION, 12) {
                tests/TestQMLWidgets \
                tests/quicknanobrowser \
                tests/webui
-    } else {
-        include($$PWD/test.pri)
     }
 
     CQtDeployer.depends=QuasarAppLib
@@ -54,4 +52,5 @@ lessThan(QT_MAJOR_VERSION, 6):lessThan(QT_MINOR_VERSION, 12) {
 
 
 }
+    include($$PWD/test.pri)
 

--- a/CQtDeployer.pro
+++ b/CQtDeployer.pro
@@ -12,6 +12,7 @@ lessThan(QT_MAJOR_VERSION, 6):lessThan(QT_MINOR_VERSION, 12) {
     warning("Tests are only enabled on Qt 5.12.0 or later version. You are using $$[QT_VERSION].")
     DEFINES += WITHOUT_TESTS
 }
+android: DEFINES += WITHOUT_TESTS
 
 !android {
     SUBDIRS += QuasarAppLib \

--- a/test.pri
+++ b/test.pri
@@ -10,12 +10,14 @@ contains(QMAKE_HOST.os, Linux):{
 DEPLOYER=cqtdeployer
 win32:DEPLOYER=$$(cqtdeployer)
 
+test.commands =
 deployTest.commands = $$DEPLOYER -bin $$exec clear -qmake $$QMAKE_BIN -targetDir $$PWD/deployTests -libDir $$PWD -recursiveDepth 4
 
-
-!android:test.depends = deployTest
-unix:!android:test.commands = $$PWD/deployTests/UnitTests.sh -maxwarnings 100000
-win32:test.commands = $$PWD/deployTests/UnitTests.exe -maxwarnings 100000 -o buildLog.log
+!android {
+    test.depends = deployTest
+    unix:test.commands = $$PWD/deployTests/UnitTests.sh -maxwarnings 100000
+    win32:test.commands = $$PWD/deployTests/UnitTests.exe -maxwarnings 100000 -o buildLog.log
+}
 
 contains(QMAKE_HOST.os, Linux):{
     win32:test.commands =

--- a/test.pri
+++ b/test.pri
@@ -13,7 +13,7 @@ win32:DEPLOYER=$$(cqtdeployer)
 test.commands =
 deployTest.commands = $$DEPLOYER -bin $$exec clear -qmake $$QMAKE_BIN -targetDir $$PWD/deployTests -libDir $$PWD -recursiveDepth 4
 
-!android {
+!contains(DEFINES, WITHOUT_TESTS) {
     test.depends = deployTest
     unix:test.commands = $$PWD/deployTests/UnitTests.sh -maxwarnings 100000
     win32:test.commands = $$PWD/deployTests/UnitTests.exe -maxwarnings 100000 -o buildLog.log


### PR DESCRIPTION
Checklist:

- [x] Allow testing on still supported versions (5.12+).
- [x] Warn users that the tests are disable.
- [x] Completely disable tests if `CONFIG` contains `WITHOUT_TESTS` .

