### PR TITLE
v1.5: make the 32-bit MinGW build to work by adding some dlls

### DIFF
--- a/Deploy/deploycore.cpp
+++ b/Deploy/deploycore.cpp
@@ -656,6 +656,7 @@ QStringList DeployCore::Qt3rdpartyLibs(Platform platform) {
 
                   // gcc runtime libs ow mingw
                   "libgcc_s_seh",
+                  "libgcc_s_dw2",
                   "libstdc++",
                   "libwinpthread",
 

--- a/UnitTests/modulesqt513.cpp
+++ b/UnitTests/modulesqt513.cpp
@@ -53,7 +53,11 @@ QSet<QString> ModulesQt513::onlyC(const QString &distDir) const
                     "./" + distDir + "/TestOnlyC.exe",
                     "./" + distDir + "/TestOnlyC.bat",
                     "./" + distDir + "/qt.conf",
+#if defined(Q_OS_WIN64)
                     "./" + distDir + "/libgcc_s_seh-1.dll",
+#else
+                    "./" + distDir + "/libgcc_s_dw2-1.dll",
+#endif
                     "./" + distDir + "/libstdc++-6.dll",
                     "./" + distDir + "/libwinpthread-1.dll",
                 }
@@ -234,7 +238,11 @@ QSet<QString> ModulesQt513::qmlLibs(const QString &distDir) const {
                     "./" + distDir + "/Qt5Widgets.dll",
                     "./" + distDir + "/TestQMLWidgets.exe",
                     "./" + distDir + "/TestQMLWidgets.bat",
+#if defined(Q_OS_WIN64)
                     "./" + distDir + "/libgcc_s_seh-1.dll",
+#else
+                    "./" + distDir + "/libgcc_s_dw2-1.dll",
+#endif
                     "./" + distDir + "/libstdc++-6.dll",
                     "./" + distDir + "/libwinpthread-1.dll",
                     "./" + distDir + "/plugins/bearer/qgenericbearer.dll",
@@ -1376,7 +1384,11 @@ QSet<QString> ModulesQt513::testDistroLibs(const QString &distDir) const {
                     "./" + distDir + "/lolLib/Qt5Gui.dll",
                     "./" + distDir + "/lolLib/Qt5Svg.dll",
                     "./" + distDir + "/lolLib/Qt5Widgets.dll",
+#if defined(Q_OS_WIN64)
                     "./" + distDir + "/lolLib/libgcc_s_seh-1.dll",
+#else
+                    "./" + distDir + "/lolLib/libgcc_s_dw2-1.dll",
+#endif
                     "./" + distDir + "/lolLib/libstdc++-6.dll",
                     "./" + distDir + "/lolLib/libwinpthread-1.dll",
                     "./" + distDir + "/lolTr/qtbase_ar.qm",
@@ -1418,7 +1430,11 @@ QSet<QString> ModulesQt513::testDistroLibs(const QString &distDir) const {
                     "./" + distDir + "/p/styles/qwindowsvistastyle.dll",
                     "./" + distDir + "/package1/TestOnlyC.exe",
                     "./" + distDir + "/package1/TestOnlyC.bat",
+#if defined(Q_OS_WIN64)
                     "./" + distDir + "/package1/libgcc_s_seh-1.dll",
+#else
+                    "./" + distDir + "/package1/libgcc_s_dw2-1.dll",
+#endif
                     "./" + distDir + "/package1/libstdc++-6.dll",
                     "./" + distDir + "/package1/libwinpthread-1.dll",
                     "./" + distDir + "/package1/qt.conf",
@@ -1436,7 +1452,11 @@ QSet<QString> ModulesQt513::testDistroLibs(const QString &distDir) const {
                     "./" + distDir + "/package2/ZzZ/Qt5Widgets.dll",
                     "./" + distDir + "/package2/ZzZ/TestQMLWidgets.exe",
                     "./" + distDir + "/package2/ZzZ/TestQMLWidgets.bat",
+#if defined(Q_OS_WIN64)
                     "./" + distDir + "/package2/ZzZ/libgcc_s_seh-1.dll",
+#else
+                    "./" + distDir + "/package2/ZzZ/libgcc_s_dw2-1.dll",
+#endif
                     "./" + distDir + "/package2/ZzZ/libstdc++-6.dll",
                     "./" + distDir + "/package2/ZzZ/libwinpthread-1.dll",
                     "./" + distDir + "/package2/ZzZ/plugins/bearer/qgenericbearer.dll",
@@ -2640,7 +2660,11 @@ QSet<QString> ModulesQt513::testOutLibs(const QString &distDir) const {
                     "./" + distDir + "/lolLib/Qt5QuickTemplates2.dll",
                     "./" + distDir + "/lolLib/Qt5Svg.dll",
                     "./" + distDir + "/lolLib/Qt5Widgets.dll",
+#if defined(Q_OS_WIN64)
                     "./" + distDir + "/lolLib/libgcc_s_seh-1.dll",
+#else
+                    "./" + distDir + "/lolLib/libgcc_s_dw2-1.dll",
+#endif
                     "./" + distDir + "/lolLib/libstdc++-6.dll",
                     "./" + distDir + "/lolLib/libwinpthread-1.dll",
                     "./" + distDir + "/lolTr/qtbase_ar.qm",

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -2876,6 +2876,10 @@ void deploytest::testSystemLib() {
                     "./" + DISTRO_DIR + "/systemLibs/msvcp_win.dll",
                     "./" + DISTRO_DIR + "/systemLibs/wtsapi32.dll",
                     "./" + DISTRO_DIR + "/systemLibs/combase.dll",
+#if !defined(Q_OS_WIN64)
+                    "./" + DISTRO_DIR + "/systemLibs/sspicli.dll",
+                    "./" + DISTRO_DIR + "/systemLibs/cryptbase.dll",
+#endif
 
                 });
 

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -2457,7 +2457,11 @@ void deploytest::testIgnore() {
                     "./" + DISTRO_DIR + "/qt.conf",
                     "./" + DISTRO_DIR + "/QtWidgetsProject.exe",
                     "./" + DISTRO_DIR + "/QtWidgetsProject.bat",
+#if defined(Q_OS_WIN64)
                     "./" + DISTRO_DIR + "/libgcc_s_seh-1.dll",
+#else
+                    "./" + DISTRO_DIR + "/libgcc_s_dw2-1.dll",
+#endif
                     "./" + DISTRO_DIR + "/libstdc++-6.dll",
                     "./" + DISTRO_DIR + "/libwinpthread-1.dll"
 
@@ -2626,7 +2630,11 @@ void deploytest::testLibDir() {
                     "./" + DISTRO_DIR + "/qt.conf",
                     "./" + DISTRO_DIR + "/TestOnlyC.exe",
                     "./" + DISTRO_DIR + "/TestOnlyC.bat",
+#if defined(Q_OS_WIN64)
                     "./" + DISTRO_DIR + "/libgcc_s_seh-1.dll",
+#else
+                    "./" + DISTRO_DIR + "/libgcc_s_dw2-1.dll",
+#endif
                     "./" + DISTRO_DIR + "/libwinpthread-1.dll",
                     "./" + DISTRO_DIR + "/libstdc++-6.dll",
 
@@ -2637,7 +2645,11 @@ void deploytest::testLibDir() {
                     "./" + DISTRO_DIR + "2/qt.conf",
                     "./" + DISTRO_DIR + "2/TestOnlyC.exe",
                     "./" + DISTRO_DIR + "2/TestOnlyC.bat",
+#if defined(Q_OS_WIN64)
                     "./" + DISTRO_DIR + "2/libgcc_s_seh-1.dll",
+#else
+                    "./" + DISTRO_DIR + "2/libgcc_s_dw2-1.dll",
+#endif
                     "./" + DISTRO_DIR + "2/libstdc++-6.dll",
 
                 });
@@ -2678,7 +2690,11 @@ void deploytest::testLibDir() {
                     "./" + DISTRO_DIR + "/qt.conf",
                     "./" + DISTRO_DIR + "/TestOnlyC.exe",
                     "./" + DISTRO_DIR + "/TestOnlyC.bat",
+#if defined(Q_OS_WIN64)
                     "./" + DISTRO_DIR + "/libgcc_s_seh-1.dll",
+#else
+                    "./" + DISTRO_DIR + "/libgcc_s_dw2-1.dll",
+#endif
                     "./" + DISTRO_DIR + "/libstdc++-6.dll",
 
                 });
@@ -2806,7 +2822,11 @@ void deploytest::testSystemLib() {
     {
                     "./" + DISTRO_DIR + "/TestOnlyC.exe",
                     "./" + DISTRO_DIR + "/TestOnlyC.bat",
+#if defined(Q_OS_WIN64)
                     "./" + DISTRO_DIR + "/systemLibs/libgcc_s_seh-1.dll",
+#else
+                    "./" + DISTRO_DIR + "/systemLibs/libgcc_s_dw2-1.dll",
+#endif
                     "./" + DISTRO_DIR + "/systemLibs/libstdc++-6.dll",
                     "./" + DISTRO_DIR + "/systemLibs/libwinpthread-1.dll",
                     "./" + DISTRO_DIR + "/systemLibs/msvcrt.dll",
@@ -2829,7 +2849,11 @@ void deploytest::testSystemLib() {
     {
                     "./" + DISTRO_DIR + "/TestOnlyC.exe",
                     "./" + DISTRO_DIR + "/TestOnlyC.bat",
+#if defined(Q_OS_WIN64)
                     "./" + DISTRO_DIR + "/systemLibs/libgcc_s_seh-1.dll",
+#else
+                    "./" + DISTRO_DIR + "/systemLibs/libgcc_s_dw2-1.dll",
+#endif
                     "./" + DISTRO_DIR + "/systemLibs/libstdc++-6.dll",
                     "./" + DISTRO_DIR + "/systemLibs/libwinpthread-1.dll",
 


### PR DESCRIPTION
Fix for issue #580 .

I added these dlls:

- libgcc_s_dw2-1.dll
- sspicli.dll
- cryptbase.dll

See the commit message for details.
