### PR TITLE
Force sets utf-8 format for the deploy qifw tempaltes

### DIFF
--- a/Deploy/Distributions/idistribution.cpp
+++ b/Deploy/Distributions/idistribution.cpp
@@ -9,6 +9,7 @@
 #include "pathutils.h"
 #include <QDate>
 #include <QMap>
+#include <QTextCodec>
 #include <deployconfig.h>
 #include <distromodule.h>
 #include <quasarapp.h>
@@ -80,6 +81,7 @@ bool iDistribution::unpackFile(const QFileInfo &resource,
         }
 
         QTextStream stream(&file);
+        stream.setCodec(QTextCodec::codecForName("UTF-8"));
         stream << inputText;
     } else {
         file.write(inputData);


### PR DESCRIPTION
The fix of the codecs qt installer framework templates.  