### PR TITLE
Fix qt.conf

### DIFF
--- a/Deploy/metafilemanager.cpp
+++ b/Deploy/metafilemanager.cpp
@@ -214,15 +214,14 @@ bool MetaFileManager::createQConf(const QString &target) {
         return false;
     }
     auto distro = cnf->getDistro(target);
-
+    QString prefix = distro.getRootDir(distro.getBinOutDir());
     QString content =
             "[Paths]\n"
-            "Prefix= ." + distro.getRootDir(distro.getBinOutDir()) + "\n"
-            "Libraries= ." + distro.getLibOutDir() + "\n"
-            "Plugins= ." + distro.getPluginsOutDir() + "\n"
-            "Imports= ." + distro.getQmlOutDir() + "\n"
-            "Translations= ." + distro.getTrOutDir() + "\n"
-            "Qml2Imports= ." + distro.getQmlOutDir() + "\n";
+            "Libraries= ." + prefix + distro.getLibOutDir() + "\n"
+            "Plugins= ." + prefix + distro.getPluginsOutDir() + "\n"
+            "Imports= ." + prefix + distro.getQmlOutDir() + "\n"
+            "Translations= ." + prefix + distro.getTrOutDir() + "\n"
+            "Qml2Imports= ." + prefix + distro.getQmlOutDir() + "\n";
 
 
     content.replace("//", "/");

--- a/UnitTests/tst_deploytest.cpp
+++ b/UnitTests/tst_deploytest.cpp
@@ -96,17 +96,16 @@ private slots:
     void testOverwrite();
     void testOverwriteWithPacking();
 
+    // tested flags confFile
+    void testConfFile();
+
     // tested flags binDir
     void testextraData();
 
     // tested flags qmlDir qmake
     void testQt();
 
-
     void testWebEngine();
-
-    // tested flags confFile
-    void testConfFile();
 
     // tested flags targetPackage
     void testPackages();
@@ -2844,12 +2843,11 @@ void deploytest::testOutDirs() {
     auto runScript = file.readAll();
     file.close();
 
-    QVERIFY(runScript.contains("Prefix= ./../"));
-    QVERIFY(runScript.contains("Libraries= ./lolLib/"));
-    QVERIFY(runScript.contains("Plugins= ./p/"));
-    QVERIFY(runScript.contains("Imports= ./q/"));
-    QVERIFY(runScript.contains("Translations= ./lolTr/"));
-    QVERIFY(runScript.contains("Qml2Imports= ./q/"));
+    QVERIFY(runScript.contains("Libraries= ./../lolLib/"));
+    QVERIFY(runScript.contains("Plugins= ./../p/"));
+    QVERIFY(runScript.contains("Imports= ./../q/"));
+    QVERIFY(runScript.contains("Translations= ./../lolTr/"));
+    QVERIFY(runScript.contains("Qml2Imports= ./../q/"));
 
 #ifdef Q_OS_WIN
 


### PR DESCRIPTION
Some times The Qt Framework have a bugs. In Qt 5.15 not working carectly prefix om qt.conf, but default value works correctly.
so we remove the custom value of the prefix and move it relative ApplicationDir path.

See the qt [documentation](https://doc.qt.io/qt-5/qt-conf.html) for more information.