### PR TITLE
Fix the wrong condition check about appending ";%cqtDir%" to PATH

### DIFF
--- a/QIFData/packages/cqtdeployer.1_5/meta/installscript.js
+++ b/QIFData/packages/cqtdeployer.1_5/meta/installscript.js
@@ -106,7 +106,7 @@ function systemIntegration() {
 
         console.log("path befor strip : " + PATH);
 
-        if (!PATH.includes(cqtDir) || !cqtDir.length) {
+        if (!PATH.includes(cqtDir) && cqtDir.length) {
             PATH = stripWinPath(PATH);
             console.log("path after strip : " + PATH);
 


### PR DESCRIPTION
Otherwise, it will cause the environment variable PATH to become longer by appending `;%cqtDir%` to it during each installation.