### PR TITLE
Fix windows shortcuts

### DIFF
--- a/Deploy/Distributions/idistribution.cpp
+++ b/Deploy/Distributions/idistribution.cpp
@@ -220,24 +220,23 @@ bool iDistribution::collectInfo(const DistroModule& pkg,
         auto targetInfo =  cfg->targets().value(target);
 
         if (targetInfo.getShortCut()) {
+
             if (cmdArray.size() > initSize) {
+                cmdArray += ",";
+                bashArray += " ";
                 cmdShortCutsArray += ",";
                 bashShortCutsArray += " ";
             }
 
+            cmdArray += "\"" + fileinfo.baseName() + "\"";
+            bashArray += "\"" + fileinfo.baseName() + "\"";
+
+
             cmdShortCutsArray += "\"" + targetInfo.getRunScriptFile() + "\"";
             bashShortCutsArray += "\"" + targetInfo.getRunScriptFile() + "\"";
         }
-
-        if (fileinfo.suffix().compare("exe", Qt::CaseInsensitive) == 0 || fileinfo.suffix().isEmpty()) {
-            if (cmdArray.size() > initSize) {
-                cmdArray += ",";
-                bashArray += " ";
-            }
-            cmdArray += "\"" + fileinfo.baseName() + "\"";
-            bashArray += "\"" + fileinfo.baseName() + "\"";
-        }
     }
+
     cmdArray += "]";
     bashArray += ")";
     cmdShortCutsArray += "]";

--- a/Deploy/targetinfo.cpp
+++ b/Deploy/targetinfo.cpp
@@ -40,7 +40,12 @@ void TargetInfo::setIcon(const QString &value) {
 }
 
 bool TargetInfo::getShortCut() const {
-    return _fEnableShortCut;
+    QFileInfo info(fullPath());
+    QString compleSufix = info.completeSuffix();
+
+    bool defaultRule = compleSufix.compare("exe", Qt::CaseInsensitive) == 0 || compleSufix.isEmpty();
+
+    return _fEnableShortCut && defaultRule;
 }
 
 void TargetInfo::setShortCut(bool shortcut) {
@@ -70,7 +75,7 @@ void TargetInfo::setRunScript(const QString &newRunScript) {
 
 QString TargetInfo::getRunScriptFile() const {
 
-    if (_fEnableRunScript) {
+    if (fEnableRunScript()) {
         QFileInfo runscriptInfo(getRunScript());
         QFileInfo info(getName());
 


### PR DESCRIPTION
```
Info: Caught exception: Exception while loading component script at "~installer\defaultQIFWTemplate\packages\Application\meta\installscript.qs": SyntaxError: Expected token `,' on line number: 51

Error: message =
Error: The CQtDeployer fail to Pack application.
```