### PR TITLE
Qt6: Add support for networkinformation plugins

### DIFF
--- a/src/Deploy/src/pluginsparser.cpp
+++ b/src/Deploy/src/pluginsparser.cpp
@@ -38,6 +38,7 @@ static const PluginModuleMapping pluginModuleMappings[] =
     {"playlistformats", DeployCore::QtModule::QtMultimediaModule},
     {"bearer", DeployCore::QtModule::QtNetworkModule},
     {"tls", DeployCore::QtModule::QtNetworkModule},
+    {"networkinformation", DeployCore::QtModule::QtNetworkModule},
     {"position", DeployCore::QtModule::QtPositioningModule},
     {"printsupport", DeployCore::QtModule::QtPrintSupportModule},
     {"scenegraph", DeployCore::QtModule::QtQuickModule},


### PR DESCRIPTION
Qt 6.1 added https://doc.qt.io/qt-6/qnetworkinformation.html to the network module, but this needs plugins in `networkinformation` to be deployed.