### PR TITLE
fix: improve import filter by adding a space after the import statement

### DIFF
--- a/src/Deploy/src/qmlqt6.cpp
+++ b/src/Deploy/src/qmlqt6.cpp
@@ -47,7 +47,7 @@ QStringList QMLQt6::extractImportsFromFile(const QString &filepath) const {
         {
             word = word.simplified();
             if (word.startsWith("//")) continue;
-            if (!word.startsWith("import")) continue;
+            if (!word.startsWith("import ")) continue;
 
             imports += extractImportLine(word);
         }


### PR DESCRIPTION
In the issue [821](https://github.com/QuasarApp/CQtDeployer/issues/821) the segmentation fault issue was coming up because inside one of the parsed qml files was there **import**ConfirmationPopup.open() adding in the filter a space after the import statement avoids these "fake import" to be catched.